### PR TITLE
Memory blow up when return a tensor from torch::CustomClassHolder

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <iostream>
 
 using torch::Tensor;
 using torch::autograd::tensor_list;
@@ -7,15 +8,21 @@ struct Container : torch::CustomClassHolder {
   Tensor x;
   Container() {}
   Container(Tensor x):x(x) {}
+  void release_resources() {
+    std::cout << "--------ptr release-------- " <<"\n";
+  }
 };
 
 class MyCustomFunc : public torch::autograd::Function<MyCustomFunc> {
  public:
   static Tensor forward(torch::autograd::AutogradContext* ctx, Tensor x) {
       at::AutoNonVariableTypeMode g;
-      auto ptr = c10::make_intrusive<Container>(torch::randn_like(x));
+      Container container = {torch::randn_like(x)};
+      auto ptr = c10::make_intrusive<Container>(container);
       ctx->saved_data["x"] = ptr;
-      return ptr->x;
+      Tensor t = container.x.clone().detach();
+      return container.x;  // blow up, release_resources() got called, but ptr memory doesn't got free
+      // return t;         // ptr memory got free
   }
   static tensor_list backward(torch::autograd::AutogradContext* ctx, tensor_list grad_outputs) {
       return {grad_outputs[0] * MyCustomFunc::apply(ctx->saved_data["x"].toCustomClass<Container>()->x)};
@@ -26,13 +33,13 @@ Tensor forward_autograd(Tensor x) {
    return MyCustomFunc::apply(x);
 }
 
-TORCH_LIBRARY(test, m) {
+TORCH_LIBRARY(test1, m) {
   m.class_<Container>("Container").def(
       torch::init<Tensor>());
   m.def("forward", forward_autograd);
 }
 
-TORCH_LIBRARY_IMPL(test, Autograd, m) {
+TORCH_LIBRARY_IMPL(test1, Autograd, m) {
   m.impl("forward", forward_autograd);
 }
 

--- a/test.cpp
+++ b/test.cpp
@@ -20,9 +20,8 @@ class MyCustomFunc : public torch::autograd::Function<MyCustomFunc> {
       Container container = {torch::randn_like(x)};
       auto ptr = c10::make_intrusive<Container>(container);
       ctx->saved_data["x"] = ptr;
-      Tensor t = container.x.clone().detach();
-      return container.x;  // blow up, release_resources() got called, but ptr memory doesn't got free
-      // return t;         // ptr memory got free
+      // return container.x;  // blow up, release_resources() got called, but ptr memory doesn't got free
+      return container.x.clone().detach();         // ptr memory got free
   }
   static tensor_list backward(torch::autograd::AutogradContext* ctx, tensor_list grad_outputs) {
       return {grad_outputs[0] * MyCustomFunc::apply(ctx->saved_data["x"].toCustomClass<Container>()->x)};

--- a/test.py
+++ b/test.py
@@ -5,7 +5,6 @@ import torch.utils.cpp_extension
 
 torch.ops.load_library('build/lib.macosx-11-arm64-3.9/test.cpython-39-darwin.so')
 
-
 def checkgpu(device=None):
     i = device if device else torch.cuda.current_device()
     t = torch.cuda.get_device_properties(i).total_memory
@@ -21,8 +20,8 @@ def checkgpu(device=None):
     return f'{(info.used / 1024 / 1024):.1f}MB'
 
 
-for i in range(10):
-    x = torch.zeros(1024*1024*50, requires_grad=True, device='cuda')
+for i in range(5):
+    x = torch.zeros(1024*1024*80, requires_grad=True, device='cuda')
     y = torch.ops.test1.forward(x)
     g = torch.autograd.grad(y, x, y, create_graph=True, retain_graph=True)[0]
     g.sum().backward()

--- a/test.py
+++ b/test.py
@@ -1,11 +1,31 @@
 import torch
-import tqdm
+import pynvml
+import os
 import torch.utils.cpp_extension
 
 torch.ops.load_library('build/lib.macosx-11-arm64-3.9/test.cpython-39-darwin.so')
 
-for i in tqdm.trange(100000):
-    x = torch.zeros(1024*1024*512, requires_grad=True)
-    y = torch.ops.test.forward(x).sum()
-    g = torch.autograd.grad(y, x, create_graph=True, retain_graph=True)[0]
+
+def checkgpu(device=None):
+    i = device if device else torch.cuda.current_device()
+    t = torch.cuda.get_device_properties(i).total_memory
+    c = torch.cuda.memory_reserved(i)
+    name = torch.cuda.get_device_properties(i).name
+    print('   GPU Memory Cached (pytorch) : {:7.1f}MB / {:.1f}MB ({})'.format(c / 1024 / 1024, t / 1024 / 1024, name))
+    real_i = int(os.environ['CUDA_VISIBLE_DEVICES'][0]) if 'CUDA_VISIBLE_DEVICES' in os.environ else i
+    pynvml.nvmlInit()
+    h = pynvml.nvmlDeviceGetHandleByIndex(real_i)
+    info = pynvml.nvmlDeviceGetMemoryInfo(h)
+    name = pynvml.nvmlDeviceGetName(h)
+    print('   GPU Memory Used (nvidia-smi): {:7.1f}MB / {:.1f}MB ({})'.format(info.used / 1024 / 1024, info.total / 1024 / 1024, name.decode()))
+    return f'{(info.used / 1024 / 1024):.1f}MB'
+
+
+for i in range(10):
+    x = torch.zeros(1024*1024*50, requires_grad=True, device='cuda')
+    y = torch.ops.test1.forward(x)
+    g = torch.autograd.grad(y, x, y, create_graph=True, retain_graph=True)[0]
     g.sum().backward()
+    print(i)
+    checkgpu()
+    print('-' * 70)


### PR DESCRIPTION
`return container.x`
```
--------ptr release--------
--------ptr release--------
0
   GPU Memory Cached (pytorch) :  2562.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  3191.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
1
   GPU Memory Cached (pytorch) :  3842.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  4471.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
2
   GPU Memory Cached (pytorch) :  5122.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  5751.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
3
   GPU Memory Cached (pytorch) :  6402.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  7031.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
Traceback (most recent call last):
  File "test.py", line 28, in <module>
    g.sum().backward()
  File "/home/richard/program/anaconda3/envs/cuaev/lib/python3.8/site-packages/torch/tensor.py", line 251, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/home/richard/program/anaconda3/envs/cuaev/lib/python3.8/site-packages/torch/autograd/__init__.py", line 145, in backward
    Variable._execution_engine.run_backward(
RuntimeError: CUDA out of memory. Tried to allocate 320.00 MiB (GPU 0; 7.93 GiB total capacity; 7.19 GiB already allocated; 128.06 MiB free; 7.19 GiB reserved in total by PyTorch)
```

`container.x.clone().detach()`

```
--------ptr release--------
--------ptr release--------
0
   GPU Memory Cached (pytorch) :  2242.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  2871.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
--------ptr release--------
1
   GPU Memory Cached (pytorch) :  2882.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  3511.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
--------ptr release--------
2
   GPU Memory Cached (pytorch) :  2882.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  3511.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
--------ptr release--------
3
   GPU Memory Cached (pytorch) :  2882.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  3511.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
--------ptr release--------
--------ptr release--------
4
   GPU Memory Cached (pytorch) :  2882.0MB / 8119.6MB (GeForce GTX 1080)
   GPU Memory Used (nvidia-smi):  3511.5MB / 8119.6MB (GeForce GTX 1080)
----------------------------------------------------------------------
--------ptr release--------
```